### PR TITLE
Adds option to provide an OpenAI project id

### DIFF
--- a/lib/openai_ex.ex
+++ b/lib/openai_ex.ex
@@ -9,6 +9,7 @@ defmodule OpenaiEx do
   """
   defstruct token: nil,
             organization: nil,
+            project: nil,
             beta: nil,
             base_url: "https://api.openai.com/v1",
             receive_timeout: 15_000,
@@ -22,17 +23,22 @@ defmodule OpenaiEx do
 
   See https://platform.openai.com/docs/api-reference/authentication for details.
   """
-  def new(token, organization \\ nil) do
+  def new(token, organization \\ nil, project \\ nil) do
     headers =
       [{"Authorization", "Bearer #{token}"}] ++
         if(is_nil(organization),
           do: [],
           else: [{"OpenAI-Organization", organization}]
+        ) ++
+        if(is_nil(project),
+          do: [],
+          else: [{"OpenAI-Project", project}]
         )
 
     %OpenaiEx{
       token: token,
       organization: organization,
+      project: project,
       _http_headers: headers
     }
   end


### PR DESCRIPTION
Given that the library already supports the `OpenAI-Organization` header, it made sense to give similar treatment for the `OpenAI-Project` header as outlined [here](https://platform.openai.com/docs/api-reference/organizations-and-projects-optional).

I am open to any feedback or changes you'd prefer. Just let me know!

Thank you for the library @restlessronin !