### PR TITLE
Allow arbitrary HTTP headers to be added to requests

### DIFF
--- a/lib/openai_ex.ex
+++ b/lib/openai_ex.ex
@@ -116,13 +116,11 @@ defmodule OpenaiEx do
     openai |> Map.put(:base_url, base_url)
   end
 
+  @spec with_additional_headers(%OpenaiEx{}, map()) :: %OpenaiEx{}
   def with_additional_headers(openai = %OpenaiEx{}, additional_headers) do
-    openai |> Map.get_and_update(
-      :_http_headers,
-      fn headers ->
-        {headers, headers ++ additional_headers}
-      end
-    ) |> elem(1)
+    Map.update(openai, :_http_headers, [], fn existing_headers ->
+      existing_headers ++ Enum.to_list(additional_headers)
+    end)
   end
 
   def with_receive_timeout(openai = %OpenaiEx{}, timeout)

--- a/lib/openai_ex.ex
+++ b/lib/openai_ex.ex
@@ -116,6 +116,15 @@ defmodule OpenaiEx do
     openai |> Map.put(:base_url, base_url)
   end
 
+  def with_additional_headers(openai = %OpenaiEx{}, additional_headers) do
+    openai |> Map.get_and_update(
+      :_http_headers,
+      fn headers ->
+        {headers, headers ++ additional_headers}
+      end
+    ) |> elem(1)
+  end
+
   def with_receive_timeout(openai = %OpenaiEx{}, timeout)
       when is_integer(timeout) and timeout > 0 do
     openai |> Map.put(:receive_timeout, timeout)

--- a/lib/openai_ex.ex
+++ b/lib/openai_ex.ex
@@ -116,7 +116,6 @@ defmodule OpenaiEx do
     openai |> Map.put(:base_url, base_url)
   end
 
-  @spec with_additional_headers(%OpenaiEx{}, map()) :: %OpenaiEx{}
   def with_additional_headers(openai = %OpenaiEx{}, additional_headers) do
     Map.update(openai, :_http_headers, [], fn existing_headers ->
       existing_headers ++ Enum.to_list(additional_headers)

--- a/notebooks/userguide.livemd
+++ b/notebooks/userguide.livemd
@@ -127,6 +127,29 @@ proxy_openai =
   OpenaiEx.new(apikey) |> OpenaiEx.with_base_url("http://host.docker.internal:8000/v1")
 ```
 
+### Using an LLM gateway (e.g. [Portkey](https://portkey.ai/))
+
+LLM gateways are used to provide a virtual interface to multiple LLM providers behind a single API endpoint.
+
+Generally they work on the basis of additional HTTP headers being added that specify the model to use, the provider to use, and possibly other parameters.
+
+For example, to configure your client for openai using the portkey gateway, you would do this:
+
+```elixir
+OpenaiEx.new(open_ai_api_key) 
+  |> OpenaiEx.with_base_url("https://api.portkey.ai/v1") 
+  |> OpenaiEx.with_additional_headers(%{"x-portkey-api-key"=>portkey_api_key, "x-portkey-provider"=>"openai"})
+```
+
+similarly, for Anthropic, you would do this:
+
+```elixir
+OpenaiEx.new(anthropic_api_key) 
+  |> OpenaiEx.with_base_url("https://api.portkey.ai/v1") 
+  |> OpenaiEx.with_additional_headers(%{"x-portkey-api-key"=>portkey_api_key, "x-portkey-provider"=>"anthropic"})
+```
+
+
 ### Azure OpenAI
 
 The Azure OpenAI API replicates the Completion, Chat Completion and Embeddings endpoints from OpenAI.


### PR DESCRIPTION
Adds a single function, `with_additional_headers/1` that adds whatever heads the caller wants to the base request.

This is useful for e.g. using [portkey's](https://docs.portkey.ai/docs/integrations/llms/openai) LLM gateway.
