### PR TITLE
Add store parameter to Chat Completion API call

### DIFF
--- a/lib/openai_ex/chat_completions.ex
+++ b/lib/openai_ex/chat_completions.ex
@@ -18,6 +18,7 @@ defmodule OpenaiEx.Chat.Completions do
     :seed,
     :service_tier,
     :stop,
+    :store,
     :stream_options,
     :temperature,
     :top_p,


### PR DESCRIPTION
It seems the parameter `store` came later. Documentation here: https://platform.openai.com/docs/api-reference/chat/create#chat-create-store