### PR TITLE
Fix/add multiple images

### DIFF
--- a/lib/openai_ex/http.ex
+++ b/lib/openai_ex/http.ex
@@ -47,16 +47,13 @@ defmodule OpenaiEx.Http do
     |> Map.take(file_fields)
     |> Enum.reduce(mp, fn {k, v}, acc ->
       case v do
-        # Handle list of file paths for multiple images
         list when is_list(list) ->
           Enum.with_index(list)
           |> Enum.reduce(acc, fn {item, idx}, inner_acc ->
-            # Use the array notation for form fields: image[]
             field_name = "#{k}[]"
             inner_acc |> Multipart.add_part(to_file_field_part(field_name, item))
           end)
 
-        # Single file/content
         _ ->
           acc |> Multipart.add_part(to_file_field_part(k, v))
       end

--- a/lib/openai_ex/http.ex
+++ b/lib/openai_ex/http.ex
@@ -49,7 +49,7 @@ defmodule OpenaiEx.Http do
       case v do
         list when is_list(list) ->
           Enum.with_index(list)
-          |> Enum.reduce(acc, fn {item, idx}, inner_acc ->
+          |> Enum.reduce(acc, fn {item, _idx}, inner_acc ->
             field_name = "#{k}[]"
             inner_acc |> Multipart.add_part(to_file_field_part(field_name, item))
           end)


### PR DESCRIPTION
Apologies, I forgot to include this in the other PR. This allows us to utilize multiple image support with the new image model, like:
```
              openai = OpenaiEx.new("API_KEY") |> OpenaiEx.with_receive_timeout(120_000)
              res = OpenaiEx.Images.edit!(openai, %{
                     image: [{image_1_path}, {image_2_path}, {image_3_path}],
                     prompt: prompt,
                     model: "gpt-image-1"
              })
```

I recommend specifying a higher timeout to those that may try it, like in the above example, because the newer model is a tad bit slower than Dall-E as of right now