### PR TITLE
fix: typos in notebooks and use Kino.Markdown for Orderbot response display

### DIFF
--- a/notebooks/dlai_orderbot.livemd
+++ b/notebooks/dlai_orderbot.livemd
@@ -115,8 +115,8 @@ We can automate the collection of user prompts and assistant responses to build 
 context = [
   ChatMessage.system("""
   You are OrderBot, an automated service to collect orders for a pizza restaurant. \
-  You first greet the customer, then collects the order, \
-  and then asks if it's a pickup or delivery. \
+  You first greet the customer, then collect the order, \
+  and then ask if it's a pickup or delivery. \
   You wait to collect the entire order, then summarize it and check for a final \
   time if the customer wants to add anything else. \
   If it's a delivery, you ask for an address. \
@@ -149,7 +149,7 @@ context = [
 append_completion = fn openai, messages, frame ->
   req = DlaiOrderbot.create_chat_req(messages: messages)
   bot_says = openai |> DlaiOrderbot.get_completion(req)
-  Kino.Frame.append(frame, Kino.Text.new("#{bot_says}"))
+  Kino.Frame.append(frame, Kino.Markdown.new("#{bot_says}"))
   bot_says
 end
 

--- a/notebooks/userguide.livemd
+++ b/notebooks/userguide.livemd
@@ -285,7 +285,7 @@ For a more in-depth example of `ChatCompletion`, check out the [Deeplearning.AI 
 
 You can also call the endpoint and have it stream the response. This returns the result as a series of tokens, which have to be put together in code.
 
-To use the stream option, call the `ChatCompletion.create()` function with `stream: true` (and `stream_options` set to `{%include_usage: true}` to recieve usage information)
+To use the stream option, call the `ChatCompletion.create()` function with `stream: true` (and `stream_options` set to `{%include_usage: true}` to receive usage information)
 
 ```elixir
 {:ok, chat_stream} = openai |> Chat.Completions.create(chat_req |> Map.put(:stream_options, %{include_usage: true}), stream: true)


### PR DESCRIPTION
I fix a few typos in the notebooks and propose to display the OrderBot replies with `Kino.Markdown`.

@restlessronin Let me know if there is anything I need to change.

Thank you for your work and time !

close #133 